### PR TITLE
feat: add i18n image for minio

### DIFF
--- a/storage-system/kustomize-gateway/base/minio/values.yaml
+++ b/storage-system/kustomize-gateway/base/minio/values.yaml
@@ -58,8 +58,8 @@ initContainers:
     name: minio-sh
 image:
   registry: k8scc01covidacr.azurecr.io
-  repository: minio
-  tag: 2021.5.27-debian-10-r8
+  repository: minio/minio
+  tag: cdb08ebe
   # registry: docker.io
   # repository: bitnami/minio
   # tag: 2021.5.27-debian-10-r8


### PR DESCRIPTION
Closes StatCan/daaas#744

Uses our i18n image of minio