### PR TITLE
update: argo workflow selector

### DIFF
--- a/daaas-system/workflows-cronjob/cron.yaml
+++ b/daaas-system/workflows-cronjob/cron.yaml
@@ -48,4 +48,4 @@ spec:
           containers:
           - name: argocli
             image: argoproj/argocli:latest
-            args: ["delete", "--all-namespaces" , "-l" , "scheduledworkflows.kubeflow.org/isOwnedByScheduledWorkflow=true", "--older" ,"5d"]
+            args: ["delete", "--all-namespaces" , "-l" , "workflows.argoproj.io/completed=true", "--older" ,"5d"]


### PR DESCRIPTION
Update the cronjob selector which cleans up argo workflows.
Closes https://github.com/StatCan/daaas/issues/828