### PR TITLE
feat(kubeflow): add kubeflow manifests draft

### DIFF
--- a/kubeflow/kubeflow.jsonnet
+++ b/kubeflow/kubeflow.jsonnet
@@ -16,7 +16,6 @@ assert std.member(["aaw-dev-cc-00", "aaw-prod-cc-00"], std.extVar('targetRevisio
             {
               app: "kubeflow-namespace",
               folder: "common",
-              version: std.extVar('targetRevision'),
               overlay: "base"
               # Example, if you need a dev/prod split, use
               # > overlay: "overlays/" + std.extVar('targetRevision')
@@ -25,103 +24,86 @@ assert std.member(["aaw-dev-cc-00", "aaw-prod-cc-00"], std.extVar('targetRevisio
             {
               app: "kubeflow-roles",
               folder: "common",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "oidc-authservice",
               folder: "common",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "knative",
               folder: "common",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "admission-webhook",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "centraldashboard",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "jupyter-web-app",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "katib",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "kfserving",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "mpi-job",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "mxnet-job",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "notebook-controller",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "pipeline",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "profiles",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "pytorch-job",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "tr-training",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "seldon",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             },
             {
               app: "spark",
               folder: "apps",
-              version: std.extVar('targetRevision'),
               overlay: "base"
             }
           ]
@@ -142,7 +124,7 @@ assert std.member(["aaw-dev-cc-00", "aaw-prod-cc-00"], std.extVar('targetRevisio
         source: {
           path: "kustomize/{{folder}}/{{app}}/{{overlay}}",
           repoURL: "https://github.com/statcan/aaw-kubeflow-manifests.git",
-          targetRevision: "{{version}}"
+          targetRevision: std.extVar('targetRevision')
         },
         syncPolicy: {
           automated: {

--- a/kubeflow/kubeflow.jsonnet
+++ b/kubeflow/kubeflow.jsonnet
@@ -1,5 +1,5 @@
 # Only have dev and prod at the moment
-assert std.member(["aaw-dev-cc-00", "aaw-prod-cc-00"], std.extVar('targetRevision'));
+assert std.member(["aaw-dev-cc-00", "aaw-prod-cc-00", "feat-kubeflow-manifests"], std.extVar('targetRevision'));
 
 {
   apiVersion: "argoproj.io/v1alpha1",
@@ -14,96 +14,78 @@ assert std.member(["aaw-dev-cc-00", "aaw-prod-cc-00"], std.extVar('targetRevisio
         list: {
           elements: [
             {
-              app: "kubeflow-namespace",
-              folder: "common",
+              app: "common/kubeflow-namespace",
               overlay: "base"
-              # Example, if you need a dev/prod split, use
-              # > overlay: "overlays/" + std.extVar('targetRevision')
-              # and have a dev and prod overlay in aaw-kubeflow-manifests.
             },
+            # Example, if you need a dev/prod split, use
+            # > overlay: "overlays/" + std.extVar('targetRevision')
+            # and have a dev and prod overlay in aaw-kubeflow-manifests.
             {
-              app: "kubeflow-roles",
-              folder: "common",
+              app: "common/kubeflow-roles",
               overlay: "base"
             },
             {
-              app: "oidc-authservice",
-              folder: "common",
+              app: "common/oidc-authservice",
               overlay: "base"
             },
             {
-              app: "knative",
-              folder: "common",
+              app: "common/knative",
               overlay: "base"
             },
             {
-              app: "admission-webhook",
-              folder: "apps",
+              app: "apps/admission-webhook",
               overlay: "base"
             },
             {
-              app: "centraldashboard",
-              folder: "apps",
+              app: "apps/centraldashboard",
               overlay: "base"
             },
             {
-              app: "jupyter-web-app",
-              folder: "apps",
+              app: "apps/jupyter-web-app",
               overlay: "base"
             },
             {
-              app: "katib",
-              folder: "apps",
+              app: "apps/katib",
               overlay: "base"
             },
             {
-              app: "kfserving",
-              folder: "apps",
+              app: "apps/kfserving",
               overlay: "base"
             },
             {
-              app: "mpi-job",
-              folder: "apps",
+              app: "apps/mpi-job",
               overlay: "base"
             },
             {
-              app: "mxnet-job",
-              folder: "apps",
+              app: "apps/mxnet-job",
               overlay: "base"
             },
             {
-              app: "notebook-controller",
-              folder: "apps",
+              app: "apps/notebook-controller",
               overlay: "base"
             },
             {
-              app: "pipeline",
-              folder: "apps",
+              app: "apps/pipeline",
               overlay: "base"
             },
             {
-              app: "profiles",
-              folder: "apps",
+              app: "apps/profiles",
               overlay: "base"
             },
             {
-              app: "pytorch-job",
-              folder: "apps",
+              app: "apps/pytorch-job",
               overlay: "base"
             },
             {
-              app: "tr-training",
-              folder: "apps",
+              app: "apps/tr-training",
               overlay: "base"
             },
             {
-              app: "seldon",
-              folder: "apps",
+              app: "apps/seldon",
               overlay: "base"
             },
             {
-              app: "spark",
-              folder: "apps",
+              app: "apps/spark",
               overlay: "base"
             }
           ]
@@ -122,7 +104,7 @@ assert std.member(["aaw-dev-cc-00", "aaw-prod-cc-00"], std.extVar('targetRevisio
         },
         project: "default",
         source: {
-          path: "kustomize/{{folder}}/{{app}}/{{overlay}}",
+          path: "kustomize/{{app}}/{{overlay}}",
           repoURL: "https://github.com/statcan/aaw-kubeflow-manifests.git",
           targetRevision: std.extVar('targetRevision')
         },

--- a/kubeflow/kubeflow.jsonnet
+++ b/kubeflow/kubeflow.jsonnet
@@ -108,12 +108,12 @@ assert std.member(["aaw-dev-cc-00", "aaw-prod-cc-00", "feat-kubeflow-manifests"]
           repoURL: "https://github.com/statcan/aaw-kubeflow-manifests.git",
           targetRevision: std.extVar('targetRevision')
         },
-        syncPolicy: {
-          automated: {
-            prune: true,
-            selfHeal: true
-          }
-        }
+        #syncPolicy: {
+        #  automated: {
+        #    prune: true,
+        #    selfHeal: true
+        #  }
+        #}
       }
     }
   }

--- a/kubeflow/kubeflow.jsonnet
+++ b/kubeflow/kubeflow.jsonnet
@@ -1,0 +1,156 @@
+# Only have dev and prod at the moment
+assert std.member(["aaw-dev-cc-00", "aaw-prod-cc-00"], std.extVar('targetRevision'));
+
+{
+  apiVersion: "argoproj.io/v1alpha1",
+  kind: "ApplicationSet",
+  metadata: {
+    name: "kubeflow",
+    namespace: "daaas-system"
+  },
+  spec: {
+    generators: [
+      {
+        list: {
+          elements: [
+            {
+              app: "kubeflow-namespace",
+              folder: "common",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+              # Example, if you need a dev/prod split, use
+              # > overlay: "overlays/" + std.extVar('targetRevision')
+              # and have a dev and prod overlay in aaw-kubeflow-manifests.
+            },
+            {
+              app: "kubeflow-roles",
+              folder: "common",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "oidc-authservice",
+              folder: "common",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "knative",
+              folder: "common",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "admission-webhook",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "centraldashboard",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "jupyter-web-app",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "katib",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "kfserving",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "mpi-job",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "mxnet-job",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "notebook-controller",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "pipeline",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "profiles",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "pytorch-job",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "tr-training",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "seldon",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            },
+            {
+              app: "spark",
+              folder: "apps",
+              version: std.extVar('targetRevision'),
+              overlay: "base"
+            }
+          ]
+        }
+      }
+    ],
+    template: {
+      metadata: {
+        name: "kubeflow-aaw",
+        namespace: "daaas-system"
+      },
+      spec: {
+        destination: {
+          name: "in-cluster",
+          namespace: "daaas-system"
+        },
+        project: "default",
+        source: {
+          path: "kustomize/{{folder}}/{{app}}/{{overlay}}",
+          repoURL: "https://github.com/statcan/aaw-kubeflow-manifests.git",
+          targetRevision: "{{version}}"
+        },
+        syncPolicy: {
+          automated: {
+            prune: true,
+            selfHeal: true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I think this is a good route for Kubeflow manifests deployment. I would recommend:

**1. Split aaw-kubeflow-manifests into a dev and prod branch**

- https://github.com/StatCan/aaw-kubeflow-manifests adopts the `aaw-dev-cc-00 (default)` and `aaw-prod-cc-00` branches
- This way, pushes to `aaw-dev-cc-00` on the aaw-kubeflow-manifests repo will be deployed immediately to dev, ditto for prod.

**2. If overlays are needed, place them in the aaw-kubeflow-manifests folders**
- If a customization is needed for a prod vs dev app (e.g. an ingress url), then in addition to the `base` folder in every aaw-kubeflow-manifests app, also include `overlays/aaw-dev-cc-00` and `overlays/aaw-prod-cc-00`
- Then the only modification that needs to be made in this repo is you modify the jsonnet file to use a dev/prod split, like [this](https://github.com/StatCan/aaw-argocd-manifests/blob/186b1a3feb81f3a8db44921bc1dc79fb1c033291/kubeflow/kubeflow.jsonnet#L16-L24)

**3. We may want to remove `stacks/argo` in order to keep a single source of ground-truth.**

Example of the rendered yaml

```yaml
# cd aaw-kubeflow-manifests
# ./jsonnet kubeflow/kubeflow.jsonnet | yq -P e -
apiVersion: argoproj.io/v1alpha1
kind: ApplicationSet
metadata:
  name: kubeflow
  namespace: daaas-system
spec:
  generators:
    - list:
        elements:
          - app: common/kubeflow-namespace
            overlay: base
          - app: common/kubeflow-roles
            overlay: base
          - app: common/oidc-authservice
            overlay: base
            # If you need dev/prod split, add overlays folders and do this:
            # > overlay: "overlays/" + std.extVar('targetRevision')
          - app: common/knative
            overlay: base
          - app: apps/admission-webhook
            overlay: base
          - app: apps/centraldashboard
            overlay: base
          - app: apps/jupyter-web-app
            overlay: base
          - app: apps/katib
            overlay: base
          - app: apps/kfserving
            overlay: base
          - app: apps/mpi-job
            overlay: base
          - app: apps/mxnet-job
            overlay: base
          - app: apps/notebook-controller
            overlay: base
          - app: apps/pipeline
            overlay: base
          - app: apps/profiles
            overlay: base
          - app: apps/pytorch-job
            overlay: base
          - app: apps/tr-training
            overlay: base
          - app: apps/seldon
            overlay: base
          - app: apps/spark
            overlay: base
  template:
    metadata:
      name: kubeflow-aaw
      namespace: daaas-system
    spec:
      destination:
        name: in-cluster
        namespace: daaas-system
      project: default
      source:
        path: kustomize/{{app}}/{{overlay}}
        repoURL: https://github.com/statcan/aaw-kubeflow-manifests.git
        targetRevision: aaw-dev-cc-00
      syncPolicy:
        automated:
          prune: true
          selfHeal: true
```

 