### PR TITLE
fix(dev): force java heap memory usage (automatic detection did not work), elastic recommendation is 50% of available memory

### DIFF
--- a/monitoring-system/eck.yaml
+++ b/monitoring-system/eck.yaml
@@ -34,6 +34,9 @@ spec:
             requests:
               cpu: "4"
               memory: 8Gi
+          env:
+          - name: ES_JAVA_OPTS
+            value: "-Xms4g -Xmx4g"
     volumeClaimTemplates:
       - metadata:
           name: elasticsearch-data


### PR DESCRIPTION
fix(dev): force java heap memory usage (automatic detection did not work), elastic recommendation is 50% of available memory