### PR TITLE
fix(minio): enable etcd

### DIFF
--- a/storage-system/kustomize-gateway/base/kustomization.yaml
+++ b/storage-system/kustomize-gateway/base/kustomization.yaml
@@ -10,7 +10,7 @@ generatorOptions:
 
 resources:
   - minio/
-  # - etcd/
+  - etcd/
   - opa/
   - networkpolicies/
 

--- a/storage-system/kustomize-gateway/base/minio/values.yaml
+++ b/storage-system/kustomize-gateway/base/minio/values.yaml
@@ -25,8 +25,8 @@ gateway:
       storageAccountKeyExistingSecret: "azure-blob-storage"
       storageAccountKeyExistingSecretKey: "storageAccountKey"
 extraEnvVars:
-  # - name: MINIO_ETCD_ENDPOINTS
-  #   value: http://minio-gateway-etcd:2379/
+  - name: MINIO_ETCD_ENDPOINTS
+    value: http://minio-gateway-etcd:2379/
   - name: MINIO_IAM_OPA_URL
     value: http://minio-gateway-opa:8181/v1/data/httpapi/authz
 extraVolumes:

--- a/storage-system/kustomize-gateway/overlays/gateway-oidc/kustomization.yaml
+++ b/storage-system/kustomize-gateway/overlays/gateway-oidc/kustomization.yaml
@@ -19,6 +19,7 @@ patchesStrategicMerge:
     metadata:
       name: minio-gateway
     spec:
+      replicas: 1
       template:
         spec:
           containers:


### PR DESCRIPTION
Closes Statcan/daaas#917

Enabled etcd to get vault working.  
Scaled MinIO UI to one replica, to be resolved in the future.