### PR TITLE
fix(argocd): remove empty key from configmap

### DIFF
--- a/kube-system/coredns-custom.yaml
+++ b/kube-system/coredns-custom.yaml
@@ -19,4 +19,3 @@ data:
     rewrite name minio-standard.aaw-dev.cloud.statcan.ca istio-ingressgateway.istio-system.svc.cluster.local
     rewrite name minio-premium.aaw-dev.cloud.statcan.ca istio-ingressgateway.istio-system.svc.cluster.local
     rewrite name max-object-detector.christian-ritter.aaw-dev.cloud.statcan.ca istio-ingressgateway.istio-system.svc.cluster.local
-  kfserving-ingress.override: |


### PR DESCRIPTION
The ignore path will work fine with or without an empty key being defined, and this way it does not clear the field!