### PR TITLE
chore(fluentd): add filter to kubeflow ns

### DIFF
--- a/daaas-system/fluentd-config.yaml
+++ b/daaas-system/fluentd-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  namespace: daaas-system
+data:
+  fluent.conf: |
+    <filter **>
+      @type grep
+      <exclude>
+        key log
+        pattern ^.*Successfully synced.*$
+      </exclude>
+    </filter>
+    <match **>
+      @type default
+    </match>

--- a/kubeflow/fluentd-config.yaml
+++ b/kubeflow/fluentd-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  namespace: kubeflow
+data:
+  fluent.conf: |
+    <filter **>
+      @type grep
+      <exclude>
+        key log
+        pattern ^.* (obs|exp|nochange): .*$
+      </exclude>
+    </filter>
+
+    <match **>
+      @type default
+    </match>


### PR DESCRIPTION
application-controller-stateful-set-0 is flooding elasticsearch with messages that we don't need, filter them out before forwarding the rest