### PR TITLE
feat(notebook scanning): initial implementation

### DIFF
--- a/daaas-system/notebook-scanning/README.md
+++ b/daaas-system/notebook-scanning/README.md
@@ -1,0 +1,26 @@
+## Purpose
+EPIC: https://github.com/StatCan/daaas/issues/461
+
+Provide a way for user notebooks to be scanned and updated.
+
+This is a WIP and we will be deploying what we have in parts (some may be combined).
+
+Here's a general run through of what will happen.
+
+Part 1:
+Get a list of notebook servers which are affected by a non-ignored vulnerability as found by jfrog XRAY.
+For the first deployment this can just be standard output written do the console.
+
+Part 2:
+Use the jupyter-web-app configmap as a truth / most up to date image, and create a list of 
+images to update to (using the output from part 1)
+
+Part 3: 
+Send user emails about their notebook images that will be updated
+
+Part 4: 
+Update the images
+
+Extra thoughts:
+May make use of annotations to see when an image was scanned and then use that as 
+information as to when to update it? Don't just send an email and then update the image right away.

--- a/daaas-system/notebook-scanning/notebook-scanning.yaml
+++ b/daaas-system/notebook-scanning/notebook-scanning.yaml
@@ -1,0 +1,66 @@
+# Namespace and secrets done from terraform
+---
+# Access notebooks across the cluster, and get read on the ConfigMap for an image to update to.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: notebook-img-cleanup-cluster-role
+rules:
+  - apiGroups: ["kubeflow.org/v1"]
+    resources: ["notebooks"] 
+    verbs: ["get", "update", "list"]
+  - apiGroups: [""]
+    resources: ["configmap"]
+    verbs: ["get"]
+---
+#Service Account
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: notebook-img-cleanup-sa
+  namespace: notebook-cleanup-system
+---
+# RoleBinding, specifically for Clusterroles
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: notebook-cleanup-system
+  name: notebook-img-cleanup-rb-cr
+subjects:
+- kind: ServiceAccount
+  name: notebook-img-cleanup-sa
+  namespace: notebook-cleanup-system
+roleRef:
+  kind: ClusterRole
+  name: notebook-img-cleanup-cluster-role
+  apiGroup: rbac.authorization.k8s.io/v1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: image-cleanup
+  namespace: notebook-cleanup-system
+spec:
+  schedule: "0 22 * * 5"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: notebook-img-cleanup-sa
+          automountServiceAccountToken: true
+          restartPolicy: OnFailure
+          containers:
+          - name: image-cleanup-job
+            image: k8scc01covidacr.azurecr.io/notebook-cleanup:ca2a0c7679e61a83f847a99bae53913ecd7ef3d1
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: JFROG_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: jfrog-aaw-notebook-scanning-secret
+                    key: jfrog_aaw_username
+              - name: JFROG_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: jfrog-aaw-notebook-scanning-secret
+                    key: jfrog_aaw_encrypted_password


### PR DESCRIPTION
This is an initial implementation that ideally, provides scan results. We initially do a kubectl get of notebook images to see what is present on the cluster. It then uses `crane` to initiate a pull of a docker image of our images on ACR through Artifactory. After the image has been pulled and scanned, we then query the XRAY api to get a list of violations. On that list we compare what was in there to that list of kubectl'd notebook images. If there is something shared, then we know that said image is vulnerable. 

These right now are output to the console as defined by the dockerfile in https://github.com/StatCan/aaw-contrib-containers/pull/87

~~Still need an image name once https://github.com/StatCan/aaw-contrib-containers/pull/87 gets merged and pushed.
But everything else can be reviewed~~