### PR TITLE
Fix(prod): certmanger version to v1

### DIFF
--- a/daaas-system/notebook-controllers/goofys-injector/manifest.yaml
+++ b/daaas-system/notebook-controllers/goofys-injector/manifest.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     apps.kubernetes.io/name: goofys-injector
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: goofys-injector-issuer
@@ -16,7 +16,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: goofys-injector

--- a/daaas-system/notebook-controllers/minio-credential-injector/manifest.yaml
+++ b/daaas-system/notebook-controllers/minio-credential-injector/manifest.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     apps.kubernetes.io/name: minio-credential-injector
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: minio-credential-injector-issuer
@@ -16,7 +16,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: minio-credential-injector

--- a/statcan-system/toleration-injector/manifest.yaml
+++ b/statcan-system/toleration-injector/manifest.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     apps.kubernetes.io/name: toleration-injector
 ---
-apiVersion: cert-manager.io/v1beta1
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: toleration-injector-issuer
@@ -16,7 +16,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1beta1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: toleration-injector


### PR DESCRIPTION
Cert-manager has ben updated to v1 in dev/prod clusters and v1alpha2 and v1beta1 are no longer valid, this makes argocd unhappy... also will allow the authenticated gateway to be created in prod!