### PR TITLE
feat(gitea): add STATIC_URL_PREFIX env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+.vscode/

--- a/profiles-argocd-system/template/gitea/manifest.yaml
+++ b/profiles-argocd-system/template/gitea/manifest.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: default
 type: Opaque
 data:
-  postgresql-postgres-password: "blF6akVwOVFoeQ=="
+  postgresql-postgres-password: "M1NFMUhSNGEzQw=="
   postgresql-password: "Z2l0ZWE="
 ---
 # Source: gitea/templates/gitea/config.yaml
@@ -51,6 +51,7 @@ stringData:
     SSH_LISTEN_PORT=2222
     SSH_PORT=22
     START_SSH_SERVER=true
+    STATIC_URL_PREFIX=/gitea/
 ---
 # Source: gitea/templates/gitea/config.yaml
 apiVersion: v1
@@ -570,7 +571,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6109a89489ef0cf6d679dbe937915328469d559b032986de822b2e2625893d6a
+        checksum/config: ccd3ca23e695b27e566114eac984789dc48b6be60dd0b58215cec418546a57e7
       labels:
         helm.sh/chart: gitea-5.0.4
         app: gitea

--- a/profiles-argocd-system/template/gitea/values.yaml
+++ b/profiles-argocd-system/template/gitea/values.yaml
@@ -39,6 +39,7 @@ gitea:
       DOMAIN: gitea
       PROTOCOL: http
       ROOT_URL: http://gitea-http
+      STATIC_URL_PREFIX: /gitea/
       SSH_DOMAIN: gitea
       ENABLE_PPROF: false
       HTTP_PORT: 3000
@@ -48,7 +49,7 @@ gitea:
       NAME: gitea
       PASSWD: gitea
       USER: gitea
-  
+
   metrics:
     enabled: false
     serviceMonitor:
@@ -76,5 +77,5 @@ postgresql:
       cpu: 500m
   persistence:
     size: 1Gi
-  
+
 checkDeprecation: true


### PR DESCRIPTION
Adding environment variable to specify url prefix for static hosted files.

Purpose of this feature is to enable rendering Gitea in Kubeflow iframe