### PR TITLE
feat(notebook restarts): dry-run only

### DIFF
--- a/daaas-system/notebook-restarting/README.md
+++ b/daaas-system/notebook-restarting/README.md
@@ -1,0 +1,16 @@
+## Purpose
+https://github.com/StatCan/daaas/issues/957
+
+This is a weekly cronjob specification alongside basic k8s rbac to facilitate the restart of user workloads.
+For quick deployment and iteration, currently I am building and pushing the image in [aaw-contrib-containers](https://github.com/StatCan/aaw-contrib-containers/tree/feat-notebook-restart/notebook-restart) inside my personal branch.
+Once image is confirmed working and behaving move it to a better github repository.
+
+
+## Requirements
+A token created in the ACR that has `read/metadata` permissions on the images pushed by [aaw-kubeflow-containers](https://github.com/StatCan/aaw-kubeflow-containers/blob/189e823e064429e2a3d056d97c2cd64f15bbd228/.github/workflows/build_push.yaml#L68)
+
+A kubernetes secret in the cluster under the `notebook-cleanup-system` namespace named `acr-metadata-read-secret` with entries for username and password.
+
+Any other relevant information can be found in the [readmes](https://github.com/StatCan/aaw-contrib-containers/tree/feat-notebook-restart/notebook-restart#patch-notebook-sts) for this specific image.
+
+This muust be ran with the argument `execute` to not invoke a dry run. For now we are doing dry-runs only

--- a/daaas-system/notebook-restarting/notebook-restarting.yaml
+++ b/daaas-system/notebook-restarting/notebook-restarting.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: notebook-restart-cluster-role
+rules:
+  - apiGroups: [""]
+    resources: ["statefulsets", "pods"]
+    verbs: ["get", "update", "list"]
+# Pods are used as they contain the `notebook-name` label 
+# Pods also used to get the statefulset name by using .metadata.OwnerReferences[].name
+# Statefulsets are what we need to restart
+---
+#Service Account
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: notebook-restart-sa
+  namespace: notebook-cleanup-system
+---
+# RoleBinding, specifically for Clusterroles
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: notebook-restart-crb
+subjects:
+- kind: ServiceAccount
+  name: notebook-restart-sa
+  namespace: notebook-cleanup-system
+roleRef:
+  kind: ClusterRole
+  name: notebook-restart-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: notebook-restart-cronjob
+  namespace: notebook-cleanup-system
+spec:
+  # 1 AM on Saturday
+  schedule: "0 1 * * 6"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: notebook-restart-sa
+          automountServiceAccountToken: true
+          restartPolicy: OnFailure
+          containers:
+          - name: notebook-restart-job
+            image: k8scc01covidacr.azurecr.io/notebook-restart:04eab57523f97ba96b9dfba22ef68a3ac0b198db
+            command: ["/bin/bash"]
+            args: ["/home/nonroot/0-the-co-ordinate.sh dry-run"]
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: ACR_READ_METADATA_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: acr-metadata-read-secret
+                    key: acr_metadata_read_username
+              - name: ACR_READ_METADATA_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: acr-metadata-read-secret
+                    key: acr_metadata_read_password


### PR DESCRIPTION
Doing dry runs first, can manually edit in argocd / turn off auto-sync to fine-tune things just need it in there.

Should wait for the _other_ pr to be merged first before merging this