### PR TITLE
Update rbac.yaml

### DIFF
--- a/daaas-system/profile-state-controller/rbac.yaml
+++ b/daaas-system/profile-state-controller/rbac.yaml
@@ -34,6 +34,14 @@ rules:
       - watch
       - get
       - list
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Need to allow the `profile-state-controller` service account to list/get/watch namespaces because the new implementation applies labels to both kubeflow profiles and namespaces.