### PR TITLE
feat(tolerationInjector): create/mount config map to toleration injector

### DIFF
--- a/statcan-system/toleration-injector/manifest.yaml
+++ b/statcan-system/toleration-injector/manifest.yaml
@@ -37,6 +37,16 @@ spec:
     name: toleration-injector-issuer
     kind: Issuer
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ns-conf
+  namespace: statcan-system
+data:
+  ns-conf.yaml: |
+    bigCPUnamespaces: 
+      - sy-test
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -74,10 +84,16 @@ spec:
         - name: certs
           mountPath: /certs
           readOnly: true
+        - name: ns-vol
+          mountPath: /app
+          subpath: ns-conf.yaml
       volumes:
       - name: certs
         secret:
           secretName: toleration-injector-tls
+      - name: ns-conf-vol
+        configMap:
+          name: ns-conf
 ---
 apiVersion: v1
 kind: Service

--- a/statcan-system/toleration-injector/manifest.yaml
+++ b/statcan-system/toleration-injector/manifest.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: statcan-system
 data:
   ns-conf.yaml: |
-    bigCPUnamespaces: 
+    bigCPUns: 
       - sy-test
 ---
 apiVersion: apps/v1

--- a/statcan-system/toleration-injector/manifest.yaml
+++ b/statcan-system/toleration-injector/manifest.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: toleration-injector
       containers:
       - name: toleration-injector
-        image: statcan/daaas-aaw-toleration-injector:364a11d7c2fc88a26c667fc5ce7d59282600cb39
+        image: statcan/daaas-aaw-toleration-injector:f53cdddfc25f122bd6328dcdc59dbb75138f6bd6
         resources:
           limits:
             memory: "128Mi"


### PR DESCRIPTION
A configmap to be used for tracking namespaces whos pods require unique tolerations to be injected. 

- [x] update image reference after github actions runs for https://github.com/StatCan/aaw-toleration-injector/pull/4

closes https://github.com/StatCan/daaas/issues/1197