### PR TITLE
Revert "feat(tolerationInjector): create/mount config map to toleration injector"

### DIFF
--- a/statcan-system/toleration-injector/manifest.yaml
+++ b/statcan-system/toleration-injector/manifest.yaml
@@ -37,16 +37,6 @@ spec:
     name: toleration-injector-issuer
     kind: Issuer
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ns-conf
-  namespace: statcan-system
-data:
-  ns-conf.yaml: |
-    bigCPUns: 
-      - sy-test
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -72,7 +62,7 @@ spec:
       serviceAccountName: toleration-injector
       containers:
       - name: toleration-injector
-        image: statcan/daaas-aaw-toleration-injector:f53cdddfc25f122bd6328dcdc59dbb75138f6bd6
+        image: statcan/daaas-aaw-toleration-injector:364a11d7c2fc88a26c667fc5ce7d59282600cb39
         resources:
           limits:
             memory: "128Mi"
@@ -84,16 +74,10 @@ spec:
         - name: certs
           mountPath: /certs
           readOnly: true
-        - name: ns-vol
-          mountPath: /app
-          subpath: ns-conf.yaml
       volumes:
       - name: certs
         secret:
           secretName: toleration-injector-tls
-      - name: ns-conf-vol
-        configMap:
-          name: ns-conf
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Reverts StatCan/aaw-argocd-manifests#152

- subpath reference requires correction to 'subPath'
- image reference will likely change when changes are made to toleration injector